### PR TITLE
Email generation now lists all common interests between mentor and mentee

### DIFF
--- a/MentorMatchmaker/MentorMatchmaker/MatchMakingDomainOperations.fs
+++ b/MentorMatchmaker/MentorMatchmaker/MatchMakingDomainOperations.fs
@@ -102,16 +102,16 @@ let rec createUniqueMentorshipMatches (collectingPairing: CollectingMentorshipPa
         let mentor = potentialMatch.Mentor
         let sessionHours = generateMeetingTimes mentee.MenteeInformation.MentorshipSchedule mentor.MentorInformation.MentorshipSchedule
         if sessionHours.Length > 0 then
-            let confirmedMentoshipMatch = {
+            let confirmedMentorshipMatch = {
                 MatchedMentee = mentee
                 MatchedMentor = mentor
-                FsharpTopic = potentialMatch.MatchingFsharpInterests.Head
+                FsharpTopic = potentialMatch.MatchingFsharpInterests
                 CouldMentorHandleMoreWork = confirmedMatches.Length + 1 = (mentor.SimultaneousMenteeCount |> int)
                 MeetingTimes = NonEmptyList.create sessionHours.Head sessionHours.Tail
             }
     
             let updatedCollectionPairing = {
-                Matches = collectingPairing.Matches |> Map.add mentor (confirmedMentoshipMatch :: confirmedMatches)
+                Matches = collectingPairing.Matches |> Map.add mentor (confirmedMentorshipMatch :: confirmedMatches)
                 MatchedMentees =  collectingPairing.MatchedMentees |> Set.add mentee
                 MatchedMentors = collectingPairing.MatchedMentors |> Set.add mentor 
                 RemainingPotentialMatches = potentialMatchesRemaining |> List.filter(fun x -> x <> potentialMatch)
@@ -256,4 +256,3 @@ module Matchmaking =
             |> String.concat("\n")
 
         System.IO.File.WriteAllText("applicationDataDump.txt", fileContent)
-

--- a/MentorMatchmaker/MentorMatchmaker/MatchMakingDomainTypes.fs
+++ b/MentorMatchmaker/MentorMatchmaker/MatchMakingDomainTypes.fs
@@ -71,7 +71,7 @@ type ConfirmedMentorshipApplication =
     { MatchedMentee: Mentee
       MatchedMentor: Mentor
       CouldMentorHandleMoreWork: bool
-      FsharpTopic: FsharpTopic
+      FsharpTopic: FsharpTopic list
       MeetingTimes: OverlapSchedule nel }
 
 let introduction = { Category = IntroductionToFSharp; PopularityWeight = PopularityWeight.Common  }

--- a/MentorMatchmaker/MentorMatchmaker/MatchMakingEmailGeneration.fs
+++ b/MentorMatchmaker/MentorMatchmaker/MatchMakingEmailGeneration.fs
@@ -12,7 +12,7 @@ module private Implementation =
             MenteeFirstName: string
             MentorEmail: string
             FssfSlack: string
-            FsharpTopic: FsharpTopic }
+            FsharpTopic: FsharpTopic list }
 
     type MenteeAndMentorPairTemplateTokens =
         {   MenteeFirstName: string
@@ -20,7 +20,7 @@ module private Implementation =
             MentorFirstName: string
             MentorFssfSlack: string
             LengthOfMentorshipInWeeks: int
-            MentorshipInterest: FsharpTopic
+            MentorshipInterest: FsharpTopic list
             MenteeEmailAddress: string
             MentorEmailAddress: string
             AvailableMeetingSessionsInUtc: OverlapSchedule nel }
@@ -29,6 +29,9 @@ module private Implementation =
         | Mentor of MentorEmailTemplateToken
         | MenteeAndMentorPair of MenteeAndMentorPairTemplateTokens
 
+    [<Literal>]
+    let LengthOfMentorshipInWeeks = 8
+    
     let transformIntoMenteeTokens (confirmedMatch: ConfirmedMentorshipApplication) =
         MenteeAndMentorPair {
             MentorshipInterest = confirmedMatch.FsharpTopic
@@ -38,14 +41,14 @@ module private Implementation =
             MentorFssfSlack = confirmedMatch.MatchedMentor.MentorInformation.SlackName
             MenteeEmailAddress = confirmedMatch.MatchedMentee.MenteeInformation.EmailAddress
             MentorEmailAddress = confirmedMatch.MatchedMentor.MentorInformation.EmailAddress
-            LengthOfMentorshipInWeeks = 8 // TODO: I need a a way to retrieve it and to make it not static....
+            LengthOfMentorshipInWeeks = LengthOfMentorshipInWeeks // TODO: I need a a way to retrieve it and to make it not static....
             AvailableMeetingSessionsInUtc = confirmedMatch.MeetingTimes
         }
 
     let transformIntoMentorTokens (confirmedMatch: ConfirmedMentorshipApplication) =
         Mentor {
             MentorFirstName = confirmedMatch.MatchedMentor.MentorInformation.FirstName
-            LengthOfMentorshipInWeeks = 8
+            LengthOfMentorshipInWeeks = LengthOfMentorshipInWeeks
             MenteeFirstName = confirmedMatch.MatchedMentee.MenteeInformation.FirstName
             MentorEmail = confirmedMatch.MatchedMentor.MentorInformation.EmailAddress
             FssfSlack = confirmedMatch.MatchedMentor.MentorInformation.SlackName
@@ -61,13 +64,18 @@ module private Implementation =
         )
         |> String.concat("\t\t\t")
 
+    let formatListOfSharedInterests menteeTokens =
+        menteeTokens.MentorshipInterest
+        |> List.map (fun topic -> topic.Name)
+        |> String.concat ", "
+    
     let replaceMenteeTemplateWithTokens (menteeTokens: MenteeAndMentorPairTemplateTokens) =
         $"
             Hello {menteeTokens.MentorFirstName} and {menteeTokens.MenteeFirstName},
  
             Congratulations! You have been selected to participate in this round of the F# Software Foundation’s Mentorship Program.
 
-            We have paired the two of you together because we noticed you’re both interested in {menteeTokens.MentorshipInterest.Name} and that your availability matched. With that said, we are hoping for great things!
+            We have paired the two of you together because we noticed you’re both interested in {formatListOfSharedInterests menteeTokens.MentorshipInterest} and that your availability matched. With that said, we are hoping for great things!
 
             As part of this round of mentorship, we’d recommend that you meet with your other half for at least one hour per week over the next {menteeTokens.LengthOfMentorshipInWeeks} weeks. We’d suggest that this be done either in person (if location allows), or via Skype, Google Hangout, Slack, etc. As a mentorship pair, the individual arrangements are left up to you to sort out.
 


### PR DESCRIPTION
To further discussion a bit, let's start with a PR aiming to expand the list of shared interests of the Mentee+Mentor pair in the pairing email.

Tested by creating a copy of the CSV schema file and adding fake data.